### PR TITLE
Add French (fr) localization

### DIFF
--- a/Sources/Markdown/fr.lproj/Localizable.strings
+++ b/Sources/Markdown/fr.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* Menu Items */
+"Find..." = "Rechercher…";
+
+/* Context Menu */
+"Context menu search item" = "Rechercher…";
+
+/* Search UI */
+"Search menu item" = "Rechercher…";
+
+/* Updater */
+"Check for Updates..." = "Rechercher les mises à jour…";
+
+/* Toast Messages */
+"QuickLook preview does not support link navigation" = "L’aperçu QuickLook ne prend pas en charge la navigation par liens";
+"Double-click .md file to open in main app for full functionality" = "Double-cliquez sur le fichier .md pour l’ouvrir dans l’application principale et accéder à toutes les fonctionnalités";


### PR DESCRIPTION
Adds `Sources/Markdown/fr.lproj/Localizable.strings` with French translations matching the existing `en` and `zh-Hans` strings.