### PR TITLE
Add "Open in External Editor" menu item

### DIFF
--- a/Sources/Markdown/MarkdownApp.swift
+++ b/Sources/Markdown/MarkdownApp.swift
@@ -204,6 +204,12 @@ struct MarkdownApp: App {
                     Text(NSLocalizedString("Reload File", comment: "Reload file menu item"))
                 }
                 .keyboardShortcut("r", modifiers: [.command])
+                Button(action: {
+                    NotificationCenter.default.post(name: .openInExternalEditor, object: nil)
+                }) {
+                    Text(NSLocalizedString("Open in External Editor", comment: "Open in external editor menu item"))
+                }
+                .keyboardShortcut("e", modifiers: [.command, .option])
                 Divider()
                 Button(action: {
                     NotificationCenter.default.post(name: .exportHTML, object: nil)

--- a/Sources/Markdown/MarkdownWebView.swift
+++ b/Sources/Markdown/MarkdownWebView.swift
@@ -182,6 +182,12 @@ struct MarkdownWebView: NSViewRepresentable {
                 name: .reloadFile,
                 object: nil
             )
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleOpenInExternalEditor),
+                name: .openInExternalEditor,
+                object: nil
+            )
         }
         
         deinit {
@@ -231,7 +237,21 @@ struct MarkdownWebView: NSViewRepresentable {
             currentWebView?.evaluateJavaScript("window.clearDiffMarks && window.clearDiffMarks();", completionHandler: nil)
             reloadFromDisk(url: url)
         }
-        
+
+        @objc func handleOpenInExternalEditor() {
+            guard let webView = currentWebView,
+                  webView.window?.isKeyWindow == true,
+                  let url = currentFileURL else { return }
+            let task = Process()
+            task.launchPath = "/usr/bin/open"
+            task.arguments = ["-t", url.path]
+            do {
+                try task.run()
+            } catch {
+                os_log("Failed to open in external editor: %{public}@", log: logger, type: .error, error.localizedDescription)
+            }
+        }
+
         @objc func handleExportHTML() {
             guard let webView = currentWebView,
                   let win = webView.window,

--- a/Sources/Markdown/en.lproj/Localizable.strings
+++ b/Sources/Markdown/en.lproj/Localizable.strings
@@ -13,3 +13,6 @@
 /* Toast Messages */
 "QuickLook preview does not support link navigation" = "QuickLook preview does not support link navigation";
 "Double-click .md file to open in main app for full functionality" = "Double-click .md file to open in main app for full functionality";
+
+/* External Editor */
+"Open in External Editor" = "Open in External Editor";

--- a/Sources/Markdown/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Markdown/zh-Hans.lproj/Localizable.strings
@@ -13,3 +13,6 @@
 /* Toast Messages */
 "QuickLook preview does not support link navigation" = "QuickLook 预览模式不支持链接跳转";
 "Double-click .md file to open in main app for full functionality" = "请双击 .md 文件用主应用打开以使用完整功能";
+
+/* External Editor */
+"Open in External Editor" = "在外部编辑器中打开";

--- a/Sources/Shared/NotificationNames.swift
+++ b/Sources/Shared/NotificationNames.swift
@@ -9,4 +9,5 @@ extension Notification.Name {
     static let zoomOut      = Notification.Name("zoomOut")
     static let resetZoom    = Notification.Name("resetZoom")
     static let reloadFile   = Notification.Name("reloadFile")
+    static let openInExternalEditor = Notification.Name("openInExternalEditor")
 }


### PR DESCRIPTION
Adds a File menu item (⌥⌘E) that opens the current document in the user's default plain-text editor via `open -t`, so users whose default `.md` association is FluxMarkdown can quickly hand off to TextEdit / an IDE / Obsidian for editing.

Localized for `en` and `zh-Hans`. Behavior is gated on the window being the key window. The QuickLook extension is unaffected.

Refs #29