### PR TITLE
Make UI language fully driven by Settings picker

### DIFF
--- a/Sources/Markdown/MarkdownApp.swift
+++ b/Sources/Markdown/MarkdownApp.swift
@@ -107,7 +107,7 @@ struct MarkdownApp: App {
                     .buttonStyle(PlainButtonStyle())
                     .background(Color(NSColor.windowBackgroundColor).opacity(0.85))
                     .clipShape(Circle())
-                    .help("Reload File (⌘R)")
+                    .help(NSLocalizedString("Reload File (⌘R)", comment: "Reload file tooltip"))
 
                     Button(action: {
                         NotificationCenter.default.post(name: .zoomOut, object: nil)
@@ -119,7 +119,7 @@ struct MarkdownApp: App {
                     .buttonStyle(PlainButtonStyle())
                     .background(Color(NSColor.windowBackgroundColor).opacity(0.85))
                     .clipShape(Circle())
-                    .help("Zoom Out")
+                    .help(NSLocalizedString("Zoom Out", comment: "Zoom out tooltip"))
 
                     Button(action: {
                         NotificationCenter.default.post(name: .resetZoom, object: nil)
@@ -131,7 +131,7 @@ struct MarkdownApp: App {
                     .buttonStyle(PlainButtonStyle())
                     .background(Color(NSColor.windowBackgroundColor).opacity(0.85))
                     .clipShape(Circle())
-                    .help("Reset Zoom (⌘0)")
+                    .help(NSLocalizedString("Reset Zoom (⌘0)", comment: "Reset zoom tooltip"))
 
                     Button(action: {
                         NotificationCenter.default.post(name: .zoomIn, object: nil)
@@ -143,7 +143,7 @@ struct MarkdownApp: App {
                     .buttonStyle(PlainButtonStyle())
                     .background(Color(NSColor.windowBackgroundColor).opacity(0.85))
                     .clipShape(Circle())
-                    .help("Zoom In")
+                    .help(NSLocalizedString("Zoom In", comment: "Zoom in tooltip"))
 
                     Button(action: {
                         NotificationCenter.default.post(name: .toggleHelp, object: nil)
@@ -155,7 +155,7 @@ struct MarkdownApp: App {
                     .buttonStyle(PlainButtonStyle())
                     .background(Color(NSColor.windowBackgroundColor).opacity(0.85))
                     .clipShape(Circle())
-                    .help("Show Help")
+                    .help(NSLocalizedString("Show Help", comment: "Show help tooltip"))
 
                     Button(action: {
                         viewMode = (viewMode == .preview) ? .source : .preview
@@ -167,7 +167,9 @@ struct MarkdownApp: App {
                     .buttonStyle(PlainButtonStyle())
                     .background(Color(NSColor.windowBackgroundColor).opacity(0.85))
                     .clipShape(Circle())
-                    .help(viewMode == .source ? "Show Preview" : "Show Source")
+                    .help(viewMode == .source
+                          ? NSLocalizedString("Show Preview", comment: "Show preview tooltip")
+                          : NSLocalizedString("Show Source", comment: "Show source tooltip"))
 
                     Button(action: {
                         switch preference.currentMode {
@@ -183,7 +185,7 @@ struct MarkdownApp: App {
                     .buttonStyle(PlainButtonStyle())
                     .background(Color(NSColor.windowBackgroundColor).opacity(0.85))
                     .clipShape(Circle())
-                    .help("Toggle Theme (System / Light / Dark)")
+                    .help(NSLocalizedString("Toggle Theme (System / Light / Dark)", comment: "Theme toggle tooltip"))
                 }
                 .padding([.top, .trailing], 10)
             }
@@ -275,18 +277,20 @@ struct MarkdownApp: App {
                 Button(action: {
                     viewMode = (viewMode == .preview) ? .source : .preview
                 }) {
-                    Text(viewMode == .source ? "Show Preview" : "Show Source")
+                    Text(viewMode == .source
+                         ? NSLocalizedString("Show Preview", comment: "Show preview menu item")
+                         : NSLocalizedString("Show Source", comment: "Show source menu item"))
                 }
                 .keyboardShortcut("m", modifiers: [.command, .shift])
 
-                Button("Reset Zoom") {
+                Button(NSLocalizedString("Reset Zoom", comment: "Reset zoom menu item")) {
                     NotificationCenter.default.post(name: .resetZoom, object: nil)
                 }
                 .keyboardShortcut("0", modifiers: .command)
 
                 Divider()
 
-                Menu("Appearance") {
+                Menu(NSLocalizedString("Appearance", comment: "Appearance submenu")) {
                     ForEach(AppearanceMode.allCases) { mode in
                         Button(action: {
                             preference.currentMode = mode

--- a/Sources/Markdown/SettingsView.swift
+++ b/Sources/Markdown/SettingsView.swift
@@ -35,9 +35,9 @@ enum SettingsTab: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .appearance: return "Appearance"
-        case .rendering: return "Rendering"
-        case .editor: return "Editor"
+        case .appearance: return NSLocalizedString("Appearance", comment: "Appearance settings tab")
+        case .rendering: return NSLocalizedString("Rendering", comment: "Rendering settings tab")
+        case .editor: return NSLocalizedString("Editor", comment: "Editor settings tab")
         }
     }
 
@@ -126,18 +126,27 @@ struct AppearanceSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            SettingsSectionHeader(title: "Theme", description: "Choose your preferred interface style")
+            SettingsSectionHeader(
+                title: NSLocalizedString("Theme", comment: "Theme section title"),
+                description: NSLocalizedString("Choose your preferred interface style", comment: "Theme section description")
+            )
 
             HStack(spacing: 0) {
-                ThemeOptionButton(mode: .light, icon: "sun.max", label: "Light", current: preference.currentMode) {
+                ThemeOptionButton(mode: .light, icon: "sun.max",
+                                  label: NSLocalizedString("Light", comment: "Light appearance mode"),
+                                  current: preference.currentMode) {
                     preference.currentMode = .light
                 }
                 Divider()
-                ThemeOptionButton(mode: .dark, icon: "moon.fill", label: "Dark", current: preference.currentMode) {
+                ThemeOptionButton(mode: .dark, icon: "moon.fill",
+                                  label: NSLocalizedString("Dark", comment: "Dark appearance mode"),
+                                  current: preference.currentMode) {
                     preference.currentMode = .dark
                 }
                 Divider()
-                ThemeOptionButton(mode: .system, icon: "circle.lefthalf.filled", label: "System", current: preference.currentMode) {
+                ThemeOptionButton(mode: .system, icon: "circle.lefthalf.filled",
+                                  label: NSLocalizedString("System", comment: "System appearance mode"),
+                                  current: preference.currentMode) {
                     preference.currentMode = .system
                 }
             }
@@ -149,15 +158,27 @@ struct AppearanceSettingsView: View {
             )
             .noFocusRing()
 
-            SettingsSectionHeader(title: "Language", description: "Interface language for the help panel")
+            SettingsSectionHeader(
+                title: NSLocalizedString("Language", comment: "Language section title"),
+                description: NSLocalizedString("Interface language for the entire app", comment: "Language section description")
+            )
 
             VStack(spacing: 0) {
-                LanguageOptionRow(label: "System Default", value: "system", current: preference.uiLanguage) {
+                LanguageOptionRow(label: NSLocalizedString("System Default", comment: "Follow OS language"),
+                                  value: "system", current: preference.uiLanguage) {
                     preference.uiLanguage = "system"
                 }
                 Divider().padding(.leading, 12)
                 LanguageOptionRow(label: "English", value: "en", current: preference.uiLanguage) {
                     preference.uiLanguage = "en"
+                }
+                Divider().padding(.leading, 12)
+                LanguageOptionRow(label: "Deutsch", value: "de", current: preference.uiLanguage) {
+                    preference.uiLanguage = "de"
+                }
+                Divider().padding(.leading, 12)
+                LanguageOptionRow(label: "Français", value: "fr", current: preference.uiLanguage) {
+                    preference.uiLanguage = "fr"
                 }
                 Divider().padding(.leading, 12)
                 LanguageOptionRow(label: "中文", value: "zh", current: preference.uiLanguage) {
@@ -229,40 +250,43 @@ struct RenderingSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            SettingsSectionHeader(title: "Features", description: "Enable or disable rendering capabilities")
+            SettingsSectionHeader(
+                title: NSLocalizedString("Features", comment: "Features section title"),
+                description: NSLocalizedString("Enable or disable rendering capabilities", comment: "Features section description")
+            )
 
             VStack(spacing: 0) {
                 FeatureToggleRow(
-                    title: "Mermaid Diagrams",
-                    subtitle: "Flowcharts, sequence diagrams, and more",
+                    title: NSLocalizedString("Mermaid Diagrams", comment: "Mermaid toggle title"),
+                    subtitle: NSLocalizedString("Flowcharts, sequence diagrams, and more", comment: "Mermaid toggle subtitle"),
                     icon: "diagram",
                     isOn: Binding(get: { preference.enableMermaid }, set: { preference.enableMermaid = $0 })
                 )
                 Divider().padding(.leading, 52)
                 FeatureToggleRow(
-                    title: "KaTeX Math",
-                    subtitle: "Mathematical expressions and equations",
+                    title: NSLocalizedString("KaTeX Math", comment: "KaTeX toggle title"),
+                    subtitle: NSLocalizedString("Mathematical expressions and equations", comment: "KaTeX toggle subtitle"),
                     icon: "function",
                     isOn: Binding(get: { preference.enableKatex }, set: { preference.enableKatex = $0 })
                 )
                 Divider().padding(.leading, 52)
                 FeatureToggleRow(
-                    title: "Emoji Support",
-                    subtitle: "GitHub flavored emoji codes like :smile:",
+                    title: NSLocalizedString("Emoji Support", comment: "Emoji toggle title"),
+                    subtitle: NSLocalizedString("GitHub flavored emoji codes like :smile:", comment: "Emoji toggle subtitle"),
                     icon: "face.smiling",
                     isOn: Binding(get: { preference.enableEmoji }, set: { preference.enableEmoji = $0 })
                 )
                 Divider().padding(.leading, 52)
                 FeatureToggleRow(
-                    title: "Collapse Blockquotes by Default",
-                    subtitle: "Collapse blockquote sections when opening a document",
+                    title: NSLocalizedString("Collapse Blockquotes by Default", comment: "Blockquote collapse toggle title"),
+                    subtitle: NSLocalizedString("Collapse blockquote sections when opening a document", comment: "Blockquote collapse toggle subtitle"),
                     icon: "text.quote",
                     isOn: Binding(get: { preference.collapseBlockquotesByDefault }, set: { preference.collapseBlockquotesByDefault = $0 })
                 )
                 Divider().padding(.leading, 52)
                 FeatureToggleRow(
-                    title: "Show Line Numbers",
-                    subtitle: "Display source line numbers in rendered preview and source view",
+                    title: NSLocalizedString("Show Line Numbers", comment: "Line numbers toggle title"),
+                    subtitle: NSLocalizedString("Display source line numbers in rendered preview and source view", comment: "Line numbers toggle subtitle"),
                     icon: "list.number",
                     isOn: Binding(get: { preference.showLineNumbers }, set: { preference.showLineNumbers = $0 })
                 )
@@ -312,11 +336,14 @@ struct EditorSettingsView: View {
         VStack(alignment: .leading, spacing: 24) {
             // Font Size
             VStack(alignment: .leading, spacing: 12) {
-                SettingsSectionHeader(title: "Typography", description: "Adjust the reading experience")
+                SettingsSectionHeader(
+                    title: NSLocalizedString("Typography", comment: "Typography section title"),
+                    description: NSLocalizedString("Adjust the reading experience", comment: "Typography section description")
+                )
 
                 VStack(spacing: 0) {
                     HStack {
-                        Text("Font Size")
+                        Text(NSLocalizedString("Font Size", comment: "Font size label"))
                             .font(.system(size: 13))
                         Spacer()
                         Text("\(Int(preference.baseFontSize))px")
@@ -354,10 +381,14 @@ struct EditorSettingsView: View {
 
             // Code Theme
             VStack(alignment: .leading, spacing: 12) {
-                SettingsSectionHeader(title: "Code Highlighting", description: "Syntax highlighting theme for code blocks")
+                SettingsSectionHeader(
+                    title: NSLocalizedString("Code Highlighting", comment: "Code theme section title"),
+                    description: NSLocalizedString("Syntax highlighting theme for code blocks", comment: "Code theme section description")
+                )
 
                 VStack(spacing: 0) {
-                    CodeThemeRow(name: "Default", id: "default", color: Color(NSColor.textColor))
+                    CodeThemeRow(name: NSLocalizedString("Default", comment: "Default code theme"),
+                                 id: "default", color: Color(NSColor.textColor))
                     Divider().padding(.leading, 36)
                     CodeThemeRow(name: "GitHub", id: "github", color: Color(red: 0.141, green: 0.161, blue: 0.243))
                     Divider().padding(.leading, 36)

--- a/Sources/Markdown/SettingsView.swift
+++ b/Sources/Markdown/SettingsView.swift
@@ -191,8 +191,33 @@ struct AppearanceSettingsView: View {
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(Color(NSColor.separatorColor), lineWidth: 1)
             )
+
+            if preference.uiLanguage != LocalizationManager.launchPreference {
+                HStack(spacing: 10) {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .foregroundColor(.accentColor)
+                    Text(NSLocalizedString("Some menus update only after restarting the app.", comment: "Restart hint"))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Button(NSLocalizedString("Restart Now", comment: "Restart now button")) {
+                        relaunchApp()
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .padding(.top, 6)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func relaunchApp() {
+        let bundleURL = Bundle.main.bundleURL
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        task.arguments = ["-n", "-a", bundleURL.path]
+        try? task.run()
+        NSApp.terminate(nil)
     }
 
     private func LanguageOptionRow(label: String, value: String, current: String, action: @escaping () -> Void) -> some View {

--- a/Sources/Markdown/SettingsView.swift
+++ b/Sources/Markdown/SettingsView.swift
@@ -212,6 +212,12 @@ struct AppearanceSettingsView: View {
     }
 
     private func relaunchApp() {
+        // Force-flush both the shared preference store (0.3s debounced) and the
+        // standard user defaults (where AppleLanguages lives) so the spawned
+        // instance reads the current picker selection, not a stale value.
+        AppearancePreference.shared.flushSharedPreferences()
+        UserDefaults.standard.synchronize()
+
         let bundleURL = Bundle.main.bundleURL
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/open")

--- a/Sources/Markdown/WelcomeView.swift
+++ b/Sources/Markdown/WelcomeView.swift
@@ -74,14 +74,14 @@ struct WelcomeView: View {
                             .stroke(Color(NSColor.separatorColor).opacity(0.8), lineWidth: 1)
                     )
                     .shadow(color: Color.black.opacity(0.12), radius: 10, x: 0, y: 6)
-                    .accessibilityLabel(Text("FluxMarkdown App Icon"))
+                    .accessibilityLabel(Text(NSLocalizedString("FluxMarkdown App Icon", comment: "App icon accessibility label")))
             }
 
             Text("FluxMarkdown")
                 .font(.system(size: 26, weight: .semibold))
                 .foregroundColor(.primary)
 
-            Text("Open a Markdown file or drop it here to start.")
+            Text(NSLocalizedString("Open a Markdown file or drop it here to start.", comment: "Welcome subtitle"))
                 .font(.system(size: 13))
                 .foregroundColor(.secondary)
         }
@@ -99,11 +99,11 @@ struct WelcomeView: View {
                             .font(.system(size: 44, weight: .semibold))
                             .foregroundColor(isTargeted ? Color.accentColor : Color.secondary)
 
-                        Text("Open Markdown File…")
+                        Text(NSLocalizedString("Open Markdown File…", comment: "Open file button"))
                             .font(.system(size: 14, weight: .semibold))
                             .foregroundColor(.primary)
 
-                        Text("Drag & drop .md/.mdx/.txt here")
+                        Text(NSLocalizedString("Drag & drop .md/.mdx/.txt here", comment: "Drop hint"))
                             .font(.system(size: 12))
                             .foregroundColor(.secondary)
 
@@ -126,19 +126,25 @@ struct WelcomeView: View {
 
     private var tips: some View {
         VStack(alignment: .leading, spacing: 10) {
+            let quickLookTitle = NSLocalizedString("QuickLook", comment: "Tip title")
+            let quickLookSubtitle = NSLocalizedString("In Finder, select a file and press Space.", comment: "QuickLook tip subtitle")
             if #available(macOS 12.0, *) {
-                TipRow(icon: "space", title: "QuickLook", subtitle: "In Finder, select a file and press Space.")
+                TipRow(icon: "space", title: quickLookTitle, subtitle: quickLookSubtitle)
             } else {
-                TipRow(icon: "keyboard", title: "QuickLook", subtitle: "In Finder, select a file and press Space.")
+                TipRow(icon: "keyboard", title: quickLookTitle, subtitle: quickLookSubtitle)
             }
-            TipRow(icon: "doc.text", title: "Open with App", subtitle: "Double-click a .md file to open it here.")
-            TipRow(icon: "arrow.down.doc", title: "Drag & Drop", subtitle: "Drop files onto the + area to open.")
+            TipRow(icon: "doc.text",
+                   title: NSLocalizedString("Open with App", comment: "Tip title"),
+                   subtitle: NSLocalizedString("Double-click a .md file to open it here.", comment: "Open with App tip subtitle"))
+            TipRow(icon: "arrow.down.doc",
+                   title: NSLocalizedString("Drag & Drop", comment: "Tip title"),
+                   subtitle: NSLocalizedString("Drop files onto the + area to open.", comment: "Drag and drop tip subtitle"))
 
             Divider()
                 .padding(.top, 2)
 
             HStack(spacing: 10) {
-                Button("Open Settings") {
+                Button(NSLocalizedString("Open Settings", comment: "Open settings button")) {
                     settingsWindowManager.show()
                 }
                 .buttonStyle(BorderlessButtonStyle())
@@ -147,7 +153,7 @@ struct WelcomeView: View {
                 Text("•")
                     .foregroundColor(Color.secondary.opacity(0.6))
 
-                Button("Troubleshooting") {
+                Button(NSLocalizedString("Troubleshooting", comment: "Troubleshooting button")) {
                     if let url = URL(string: "https://github.com/xykong/flux-markdown/blob/master/docs/user/HELP.md") {
                         openURL(url)
                     }
@@ -187,7 +193,7 @@ struct WelcomeView: View {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowedContentTypes = allowedContentTypes
-        panel.prompt = "Open"
+        panel.prompt = NSLocalizedString("Open", comment: "Open file panel prompt")
 
         if panel.runModal() == .OK {
             open(urls: panel.urls)
@@ -449,7 +455,7 @@ private final class SettingsWindowManager: NSObject {
             backing: .buffered,
             defer: false
         )
-        window.title = "Settings"
+        window.title = NSLocalizedString("Settings", comment: "Settings window title")
         window.center()
         window.contentView = hostingView
         window.isReleasedWhenClosed = false

--- a/Sources/Markdown/de.lproj/Localizable.strings
+++ b/Sources/Markdown/de.lproj/Localizable.strings
@@ -43,6 +43,8 @@
 "Language" = "Sprache";
 "Interface language for the entire app" = "Sprache der gesamten App";
 "System Default" = "Systemstandard";
+"Some menus update only after restarting the app." = "Manche Menüs werden erst nach einem Neustart der App aktualisiert.";
+"Restart Now" = "Jetzt neu starten";
 
 /* === Settings: Features Section === */
 "Features" = "Funktionen";

--- a/Sources/Markdown/de.lproj/Localizable.strings
+++ b/Sources/Markdown/de.lproj/Localizable.strings
@@ -1,18 +1,92 @@
-/* Menu Items */
+/* === Menu Items === */
+"Reload File" = "Datei neu laden";
+"Open in External Editor" = "In externem Editor öffnen";
+"Export as HTML…" = "Als HTML exportieren…";
+"Export as PDF…" = "Als PDF exportieren…";
 "Find..." = "Suchen…";
-
-/* Context Menu */
-"Context menu search item" = "Suchen…";
-
-/* Search UI */
-"Search menu item" = "Suchen…";
-
-/* Updater */
+"FluxMarkdown Help" = "FluxMarkdown-Hilfe";
+"README" = "README";
+"Report an Issue" = "Problem melden";
+"Release Notes" = "Versionshinweise";
+"Show Preview" = "Vorschau anzeigen";
+"Show Source" = "Quelltext anzeigen";
+"Reset Zoom" = "Zoom zurücksetzen";
+"Appearance" = "Erscheinungsbild";
 "Check for Updates..." = "Nach Updates suchen…";
 
-/* Toast Messages */
+/* === Context Menu / Search === */
+"Context menu search item" = "Suchen…";
+"Search menu item" = "Suchen…";
+
+/* === Toolbar Tooltips === */
+"Reload File (⌘R)" = "Datei neu laden (⌘R)";
+"Zoom Out" = "Verkleinern";
+"Reset Zoom (⌘0)" = "Zoom zurücksetzen (⌘0)";
+"Zoom In" = "Vergrößern";
+"Show Help" = "Hilfe anzeigen";
+"Toggle Theme (System / Light / Dark)" = "Erscheinungsbild wechseln (System / Hell / Dunkel)";
+
+/* === Appearance Modes === */
+"Light" = "Hell";
+"Dark" = "Dunkel";
+"System" = "System";
+
+/* === Settings: Tabs === */
+"Rendering" = "Darstellung";
+"Editor" = "Editor";
+
+/* === Settings: Theme Section === */
+"Theme" = "Erscheinungsbild";
+"Choose your preferred interface style" = "Bevorzugten Stil der Oberfläche wählen";
+
+/* === Settings: Language Section === */
+"Language" = "Sprache";
+"Interface language for the entire app" = "Sprache der gesamten App";
+"System Default" = "Systemstandard";
+
+/* === Settings: Features Section === */
+"Features" = "Funktionen";
+"Enable or disable rendering capabilities" = "Render-Funktionen aktivieren oder deaktivieren";
+"Mermaid Diagrams" = "Mermaid-Diagramme";
+"Flowcharts, sequence diagrams, and more" = "Flussdiagramme, Sequenzdiagramme und mehr";
+"KaTeX Math" = "KaTeX-Mathematik";
+"Mathematical expressions and equations" = "Mathematische Ausdrücke und Gleichungen";
+"Emoji Support" = "Emoji-Unterstützung";
+"GitHub flavored emoji codes like :smile:" = "GitHub-Emoji-Codes wie :smile:";
+"Collapse Blockquotes by Default" = "Zitat-Blöcke standardmäßig einklappen";
+"Collapse blockquote sections when opening a document" = "Zitat-Abschnitte beim Öffnen eines Dokuments einklappen";
+"Show Line Numbers" = "Zeilennummern anzeigen";
+"Display source line numbers in rendered preview and source view" = "Quellzeilennummern in der gerenderten Vorschau und der Quelltextansicht anzeigen";
+
+/* === Settings: Typography Section === */
+"Typography" = "Typografie";
+"Adjust the reading experience" = "Leseerlebnis anpassen";
+"Font Size" = "Schriftgröße";
+"Font Size:" = "Schriftgröße:";
+
+/* === Settings: Code Highlighting Section === */
+"Code Highlighting" = "Code-Hervorhebung";
+"Syntax highlighting theme for code blocks" = "Syntax-Hervorhebung für Codeblöcke";
+"Default" = "Standard";
+
+/* === Settings: Window === */
+"Settings" = "Einstellungen";
+
+/* === Welcome View === */
+"Open a Markdown file or drop it here to start." = "Markdown-Datei öffnen oder hierher ziehen, um zu beginnen.";
+"Open Markdown File…" = "Markdown-Datei öffnen…";
+"Drag & drop .md/.mdx/.txt here" = ".md/.mdx/.txt hierher ziehen";
+"QuickLook" = "QuickLook";
+"In Finder, select a file and press Space." = "Im Finder eine Datei auswählen und Leertaste drücken.";
+"Open with App" = "Mit App öffnen";
+"Double-click a .md file to open it here." = ".md-Datei doppelklicken, um sie hier zu öffnen.";
+"Drag & Drop" = "Drag & Drop";
+"Drop files onto the + area to open." = "Dateien auf den +-Bereich ziehen, um sie zu öffnen.";
+"Open Settings" = "Einstellungen öffnen";
+"Troubleshooting" = "Fehlerbehebung";
+"Open" = "Öffnen";
+"FluxMarkdown App Icon" = "FluxMarkdown-App-Symbol";
+
+/* === Toast Messages === */
 "QuickLook preview does not support link navigation" = "Die QuickLook-Vorschau unterstützt keine Link-Navigation";
 "Double-click .md file to open in main app for full functionality" = "Doppelklicke die .md-Datei, um sie in der Hauptanwendung mit vollem Funktionsumfang zu öffnen";
-
-/* External Editor */
-"Open in External Editor" = "In externem Editor öffnen";

--- a/Sources/Markdown/en.lproj/Localizable.strings
+++ b/Sources/Markdown/en.lproj/Localizable.strings
@@ -43,6 +43,8 @@
 "Language" = "Language";
 "Interface language for the entire app" = "Interface language for the entire app";
 "System Default" = "System Default";
+"Some menus update only after restarting the app." = "Some menus update only after restarting the app.";
+"Restart Now" = "Restart Now";
 
 /* === Settings: Features Section === */
 "Features" = "Features";

--- a/Sources/Markdown/en.lproj/Localizable.strings
+++ b/Sources/Markdown/en.lproj/Localizable.strings
@@ -1,18 +1,92 @@
-/* Menu Items */
+/* === Menu Items === */
+"Reload File" = "Reload File";
+"Open in External Editor" = "Open in External Editor";
+"Export as HTML…" = "Export as HTML…";
+"Export as PDF…" = "Export as PDF…";
 "Find..." = "Find...";
-
-/* Context Menu */
-"Context menu search item" = "Find...";
-
-/* Search UI */
-"Search menu item" = "Find...";
-
-/* Updater */
+"FluxMarkdown Help" = "FluxMarkdown Help";
+"README" = "README";
+"Report an Issue" = "Report an Issue";
+"Release Notes" = "Release Notes";
+"Show Preview" = "Show Preview";
+"Show Source" = "Show Source";
+"Reset Zoom" = "Reset Zoom";
+"Appearance" = "Appearance";
 "Check for Updates..." = "Check for Updates...";
 
-/* Toast Messages */
+/* === Context Menu / Search === */
+"Context menu search item" = "Find...";
+"Search menu item" = "Find...";
+
+/* === Toolbar Tooltips === */
+"Reload File (⌘R)" = "Reload File (⌘R)";
+"Zoom Out" = "Zoom Out";
+"Reset Zoom (⌘0)" = "Reset Zoom (⌘0)";
+"Zoom In" = "Zoom In";
+"Show Help" = "Show Help";
+"Toggle Theme (System / Light / Dark)" = "Toggle Theme (System / Light / Dark)";
+
+/* === Appearance Modes === */
+"Light" = "Light";
+"Dark" = "Dark";
+"System" = "System";
+
+/* === Settings: Tabs === */
+"Rendering" = "Rendering";
+"Editor" = "Editor";
+
+/* === Settings: Theme Section === */
+"Theme" = "Theme";
+"Choose your preferred interface style" = "Choose your preferred interface style";
+
+/* === Settings: Language Section === */
+"Language" = "Language";
+"Interface language for the entire app" = "Interface language for the entire app";
+"System Default" = "System Default";
+
+/* === Settings: Features Section === */
+"Features" = "Features";
+"Enable or disable rendering capabilities" = "Enable or disable rendering capabilities";
+"Mermaid Diagrams" = "Mermaid Diagrams";
+"Flowcharts, sequence diagrams, and more" = "Flowcharts, sequence diagrams, and more";
+"KaTeX Math" = "KaTeX Math";
+"Mathematical expressions and equations" = "Mathematical expressions and equations";
+"Emoji Support" = "Emoji Support";
+"GitHub flavored emoji codes like :smile:" = "GitHub flavored emoji codes like :smile:";
+"Collapse Blockquotes by Default" = "Collapse Blockquotes by Default";
+"Collapse blockquote sections when opening a document" = "Collapse blockquote sections when opening a document";
+"Show Line Numbers" = "Show Line Numbers";
+"Display source line numbers in rendered preview and source view" = "Display source line numbers in rendered preview and source view";
+
+/* === Settings: Typography Section === */
+"Typography" = "Typography";
+"Adjust the reading experience" = "Adjust the reading experience";
+"Font Size" = "Font Size";
+"Font Size:" = "Font Size:";
+
+/* === Settings: Code Highlighting Section === */
+"Code Highlighting" = "Code Highlighting";
+"Syntax highlighting theme for code blocks" = "Syntax highlighting theme for code blocks";
+"Default" = "Default";
+
+/* === Settings: Window === */
+"Settings" = "Settings";
+
+/* === Welcome View === */
+"Open a Markdown file or drop it here to start." = "Open a Markdown file or drop it here to start.";
+"Open Markdown File…" = "Open Markdown File…";
+"Drag & drop .md/.mdx/.txt here" = "Drag & drop .md/.mdx/.txt here";
+"QuickLook" = "QuickLook";
+"In Finder, select a file and press Space." = "In Finder, select a file and press Space.";
+"Open with App" = "Open with App";
+"Double-click a .md file to open it here." = "Double-click a .md file to open it here.";
+"Drag & Drop" = "Drag & Drop";
+"Drop files onto the + area to open." = "Drop files onto the + area to open.";
+"Open Settings" = "Open Settings";
+"Troubleshooting" = "Troubleshooting";
+"Open" = "Open";
+"FluxMarkdown App Icon" = "FluxMarkdown App Icon";
+
+/* === Toast Messages === */
 "QuickLook preview does not support link navigation" = "QuickLook preview does not support link navigation";
 "Double-click .md file to open in main app for full functionality" = "Double-click .md file to open in main app for full functionality";
-
-/* External Editor */
-"Open in External Editor" = "Open in External Editor";

--- a/Sources/Markdown/fr.lproj/Localizable.strings
+++ b/Sources/Markdown/fr.lproj/Localizable.strings
@@ -43,6 +43,8 @@
 "Language" = "Langue";
 "Interface language for the entire app" = "Langue de l’interface pour toute l’application";
 "System Default" = "Par défaut du système";
+"Some menus update only after restarting the app." = "Certains menus ne sont mis à jour qu’après le redémarrage de l’app.";
+"Restart Now" = "Redémarrer maintenant";
 
 /* === Settings: Features Section === */
 "Features" = "Fonctionnalités";

--- a/Sources/Markdown/fr.lproj/Localizable.strings
+++ b/Sources/Markdown/fr.lproj/Localizable.strings
@@ -1,18 +1,92 @@
-/* Menu Items */
+/* === Menu Items === */
+"Reload File" = "Recharger le fichier";
+"Open in External Editor" = "Ouvrir dans un éditeur externe";
+"Export as HTML…" = "Exporter en HTML…";
+"Export as PDF…" = "Exporter en PDF…";
 "Find..." = "Rechercher…";
-
-/* Context Menu */
-"Context menu search item" = "Rechercher…";
-
-/* Search UI */
-"Search menu item" = "Rechercher…";
-
-/* Updater */
+"FluxMarkdown Help" = "Aide FluxMarkdown";
+"README" = "README";
+"Report an Issue" = "Signaler un problème";
+"Release Notes" = "Notes de version";
+"Show Preview" = "Afficher l’aperçu";
+"Show Source" = "Afficher la source";
+"Reset Zoom" = "Réinitialiser le zoom";
+"Appearance" = "Apparence";
 "Check for Updates..." = "Rechercher les mises à jour…";
 
-/* Toast Messages */
+/* === Context Menu / Search === */
+"Context menu search item" = "Rechercher…";
+"Search menu item" = "Rechercher…";
+
+/* === Toolbar Tooltips === */
+"Reload File (⌘R)" = "Recharger le fichier (⌘R)";
+"Zoom Out" = "Zoom arrière";
+"Reset Zoom (⌘0)" = "Réinitialiser le zoom (⌘0)";
+"Zoom In" = "Zoom avant";
+"Show Help" = "Afficher l’aide";
+"Toggle Theme (System / Light / Dark)" = "Changer le thème (Système / Clair / Sombre)";
+
+/* === Appearance Modes === */
+"Light" = "Clair";
+"Dark" = "Sombre";
+"System" = "Système";
+
+/* === Settings: Tabs === */
+"Rendering" = "Rendu";
+"Editor" = "Éditeur";
+
+/* === Settings: Theme Section === */
+"Theme" = "Thème";
+"Choose your preferred interface style" = "Choisir le style d’interface préféré";
+
+/* === Settings: Language Section === */
+"Language" = "Langue";
+"Interface language for the entire app" = "Langue de l’interface pour toute l’application";
+"System Default" = "Par défaut du système";
+
+/* === Settings: Features Section === */
+"Features" = "Fonctionnalités";
+"Enable or disable rendering capabilities" = "Activer ou désactiver les capacités de rendu";
+"Mermaid Diagrams" = "Diagrammes Mermaid";
+"Flowcharts, sequence diagrams, and more" = "Organigrammes, diagrammes de séquence, etc.";
+"KaTeX Math" = "Maths KaTeX";
+"Mathematical expressions and equations" = "Expressions et équations mathématiques";
+"Emoji Support" = "Prise en charge des emojis";
+"GitHub flavored emoji codes like :smile:" = "Codes emoji style GitHub comme :smile:";
+"Collapse Blockquotes by Default" = "Réduire les citations par défaut";
+"Collapse blockquote sections when opening a document" = "Réduire les sections de citation à l’ouverture d’un document";
+"Show Line Numbers" = "Afficher les numéros de ligne";
+"Display source line numbers in rendered preview and source view" = "Afficher les numéros de ligne dans l’aperçu et la vue source";
+
+/* === Settings: Typography Section === */
+"Typography" = "Typographie";
+"Adjust the reading experience" = "Ajuster l’expérience de lecture";
+"Font Size" = "Taille de la police";
+"Font Size:" = "Taille de la police :";
+
+/* === Settings: Code Highlighting Section === */
+"Code Highlighting" = "Coloration syntaxique";
+"Syntax highlighting theme for code blocks" = "Thème de coloration pour les blocs de code";
+"Default" = "Par défaut";
+
+/* === Settings: Window === */
+"Settings" = "Réglages";
+
+/* === Welcome View === */
+"Open a Markdown file or drop it here to start." = "Ouvrir un fichier Markdown ou le déposer ici pour commencer.";
+"Open Markdown File…" = "Ouvrir un fichier Markdown…";
+"Drag & drop .md/.mdx/.txt here" = "Glisser-déposer .md/.mdx/.txt ici";
+"QuickLook" = "Coup d’œil";
+"In Finder, select a file and press Space." = "Dans le Finder, sélectionnez un fichier et appuyez sur Espace.";
+"Open with App" = "Ouvrir avec l’app";
+"Double-click a .md file to open it here." = "Double-cliquer sur un fichier .md pour l’ouvrir ici.";
+"Drag & Drop" = "Glisser-déposer";
+"Drop files onto the + area to open." = "Déposer les fichiers sur la zone + pour les ouvrir.";
+"Open Settings" = "Ouvrir les réglages";
+"Troubleshooting" = "Dépannage";
+"Open" = "Ouvrir";
+"FluxMarkdown App Icon" = "Icône de l’app FluxMarkdown";
+
+/* === Toast Messages === */
 "QuickLook preview does not support link navigation" = "L’aperçu QuickLook ne prend pas en charge la navigation par liens";
 "Double-click .md file to open in main app for full functionality" = "Double-cliquez sur le fichier .md pour l’ouvrir dans l’application principale et accéder à toutes les fonctionnalités";
-
-/* External Editor */
-"Open in External Editor" = "Ouvrir dans un éditeur externe";

--- a/Sources/Markdown/main.swift
+++ b/Sources/Markdown/main.swift
@@ -1,5 +1,9 @@
 import AppKit
 
+// Install the runtime localization swizzle and apply the persisted language
+// preference before any view, menu or scene is built.
+LocalizationManager.bootstrap(initialPreference: AppearancePreference.shared.uiLanguage)
+
 if CommandLine.arguments.contains("--export-pdf") {
     let delegate = CLIAppDelegate()
     let app = NSApplication.shared

--- a/Sources/Markdown/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Markdown/zh-Hans.lproj/Localizable.strings
@@ -1,18 +1,92 @@
-/* Menu Items */
+/* === Menu Items === */
+"Reload File" = "重新加载文件";
+"Open in External Editor" = "在外部编辑器中打开";
+"Export as HTML…" = "导出为 HTML…";
+"Export as PDF…" = "导出为 PDF…";
 "Find..." = "查找...";
-
-/* Context Menu */
-"Context menu search item" = "查找...";
-
-/* Search UI */
-"Search menu item" = "查找...";
-
-/* Updater */
+"FluxMarkdown Help" = "FluxMarkdown 帮助";
+"README" = "README";
+"Report an Issue" = "报告问题";
+"Release Notes" = "发行说明";
+"Show Preview" = "显示预览";
+"Show Source" = "显示源码";
+"Reset Zoom" = "重置缩放";
+"Appearance" = "外观";
 "Check for Updates..." = "检查更新...";
 
-/* Toast Messages */
+/* === Context Menu / Search === */
+"Context menu search item" = "查找...";
+"Search menu item" = "查找...";
+
+/* === Toolbar Tooltips === */
+"Reload File (⌘R)" = "重新加载文件 (⌘R)";
+"Zoom Out" = "缩小";
+"Reset Zoom (⌘0)" = "重置缩放 (⌘0)";
+"Zoom In" = "放大";
+"Show Help" = "显示帮助";
+"Toggle Theme (System / Light / Dark)" = "切换主题(系统 / 浅色 / 深色)";
+
+/* === Appearance Modes === */
+"Light" = "浅色";
+"Dark" = "深色";
+"System" = "系统";
+
+/* === Settings: Tabs === */
+"Rendering" = "渲染";
+"Editor" = "编辑器";
+
+/* === Settings: Theme Section === */
+"Theme" = "主题";
+"Choose your preferred interface style" = "选择您偏好的界面风格";
+
+/* === Settings: Language Section === */
+"Language" = "语言";
+"Interface language for the entire app" = "整个应用的界面语言";
+"System Default" = "系统默认";
+
+/* === Settings: Features Section === */
+"Features" = "功能";
+"Enable or disable rendering capabilities" = "启用或禁用渲染功能";
+"Mermaid Diagrams" = "Mermaid 图表";
+"Flowcharts, sequence diagrams, and more" = "流程图、时序图等";
+"KaTeX Math" = "KaTeX 数学";
+"Mathematical expressions and equations" = "数学表达式与公式";
+"Emoji Support" = "Emoji 支持";
+"GitHub flavored emoji codes like :smile:" = "GitHub 风格的 emoji 代码,如 :smile:";
+"Collapse Blockquotes by Default" = "默认折叠引用块";
+"Collapse blockquote sections when opening a document" = "打开文档时折叠引用块部分";
+"Show Line Numbers" = "显示行号";
+"Display source line numbers in rendered preview and source view" = "在渲染预览和源码视图中显示源行号";
+
+/* === Settings: Typography Section === */
+"Typography" = "排版";
+"Adjust the reading experience" = "调整阅读体验";
+"Font Size" = "字体大小";
+"Font Size:" = "字体大小:";
+
+/* === Settings: Code Highlighting Section === */
+"Code Highlighting" = "代码高亮";
+"Syntax highlighting theme for code blocks" = "代码块的语法高亮主题";
+"Default" = "默认";
+
+/* === Settings: Window === */
+"Settings" = "设置";
+
+/* === Welcome View === */
+"Open a Markdown file or drop it here to start." = "打开 Markdown 文件或拖放至此处以开始。";
+"Open Markdown File…" = "打开 Markdown 文件…";
+"Drag & drop .md/.mdx/.txt here" = "将 .md/.mdx/.txt 拖放至此";
+"QuickLook" = "快速查看";
+"In Finder, select a file and press Space." = "在访达中选择文件并按空格键。";
+"Open with App" = "用应用打开";
+"Double-click a .md file to open it here." = "双击 .md 文件即可在此打开。";
+"Drag & Drop" = "拖放";
+"Drop files onto the + area to open." = "将文件拖到 + 区域以打开。";
+"Open Settings" = "打开设置";
+"Troubleshooting" = "故障排除";
+"Open" = "打开";
+"FluxMarkdown App Icon" = "FluxMarkdown 应用图标";
+
+/* === Toast Messages === */
 "QuickLook preview does not support link navigation" = "QuickLook 预览模式不支持链接跳转";
 "Double-click .md file to open in main app for full functionality" = "请双击 .md 文件用主应用打开以使用完整功能";
-
-/* External Editor */
-"Open in External Editor" = "在外部编辑器中打开";

--- a/Sources/Markdown/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Markdown/zh-Hans.lproj/Localizable.strings
@@ -43,6 +43,8 @@
 "Language" = "语言";
 "Interface language for the entire app" = "整个应用的界面语言";
 "System Default" = "系统默认";
+"Some menus update only after restarting the app." = "部分菜单需要重新启动应用后才会更新。";
+"Restart Now" = "立即重新启动";
 
 /* === Settings: Features Section === */
 "Features" = "功能";

--- a/Sources/MarkdownPreview/PreviewViewController.swift
+++ b/Sources/MarkdownPreview/PreviewViewController.swift
@@ -224,11 +224,13 @@ public class PreviewViewController: NSViewController, QLPreviewingController, WK
     public override init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         os_log("🔵 init(nibName:bundle:) called", log: logger, type: .debug)
+        LocalizationManager.bootstrap(initialPreference: AppearancePreference.shared.uiLanguage)
     }
-    
+
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
         os_log("🔵 init(coder:) called", log: logger, type: .debug)
+        LocalizationManager.bootstrap(initialPreference: AppearancePreference.shared.uiLanguage)
     }
     
     private var themeButton: NSButton!

--- a/Sources/Shared/AppearancePreference.swift
+++ b/Sources/Shared/AppearancePreference.swift
@@ -11,9 +11,9 @@ public enum AppearanceMode: String, CaseIterable, Identifiable {
     
     public var displayName: String {
         switch self {
-        case .light: return "Light"
-        case .dark: return "Dark"
-        case .system: return "System"
+        case .light: return NSLocalizedString("Light", comment: "Light appearance mode")
+        case .dark: return NSLocalizedString("Dark", comment: "Dark appearance mode")
+        case .system: return NSLocalizedString("System", comment: "System appearance mode")
         }
     }
     
@@ -191,6 +191,7 @@ public class AppearancePreference: ObservableObject {
             objectWillChange.send()
             sharedStore.set(newValue, forKey: uiLanguageKey)
             scheduleSyncToSharedStore()
+            LocalizationManager.apply(languageCode: newValue)
         }
     }
 

--- a/Sources/Shared/AppearancePreference.swift
+++ b/Sources/Shared/AppearancePreference.swift
@@ -192,6 +192,7 @@ public class AppearancePreference: ObservableObject {
             sharedStore.set(newValue, forKey: uiLanguageKey)
             scheduleSyncToSharedStore()
             LocalizationManager.apply(languageCode: newValue)
+            LocalizationManager.applyAppleLanguages(for: newValue)
         }
     }
 

--- a/Sources/Shared/LocalizationManager.swift
+++ b/Sources/Shared/LocalizationManager.swift
@@ -23,11 +23,39 @@ public enum LocalizationManager {
         }
     }
 
-    /// Install the bundle subclass and apply the initial preference. Safe to
-    /// call multiple times.
+    /// The preference that was active when `bootstrap` first ran. Used by the
+    /// Settings UI to detect "needs restart for system menus" situations,
+    /// because `AppleLanguages` is only honored at process start by AppKit,
+    /// SwiftUI's `Settings` scene, and Sparkle.
+    public private(set) static var launchPreference: String = "system"
+    private static var didBootstrap = false
+
+    /// Install the bundle subclass, persist `AppleLanguages` so AppKit /
+    /// SwiftUI / Sparkle pick up the chosen language on this process run, and
+    /// apply the initial preference to our own `NSLocalizedString` lookups.
+    /// Safe to call multiple times — only the first call seeds the AppKit
+    /// language and the launch preference.
     public static func bootstrap(initialPreference: String) {
+        if !didBootstrap {
+            didBootstrap = true
+            launchPreference = initialPreference
+            applyAppleLanguages(for: initialPreference)
+        }
         object_setClass(Bundle.main, LocalizationBundle.self)
         apply(languageCode: initialPreference)
+    }
+
+    /// Pin AppleLanguages for this app's domain so AppKit / SwiftUI / Sparkle
+    /// honor the picker on next launch. Pass `"system"` to clear the override
+    /// and fall back to the OS-level setting.
+    public static func applyAppleLanguages(for preference: String) {
+        let key = "AppleLanguages"
+        let defaults = UserDefaults.standard
+        if let dir = lprojName(for: preference) {
+            defaults.set([dir], forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
     }
 
     /// Activate the given preference value. Pass `"system"` to revert to the

--- a/Sources/Shared/LocalizationManager.swift
+++ b/Sources/Shared/LocalizationManager.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Runtime-switchable localization for `NSLocalizedString`.
+///
+/// macOS normally resolves `NSLocalizedString` against the bundle's preferred
+/// localization, picked once at launch from the system language list. To let
+/// the in-app Settings picker change the UI language without restarting the
+/// process, we swap `Bundle.main`'s class to a subclass that consults a
+/// per-language sub-bundle stored in `SwizzleBundleStorage`.
+///
+/// Call `LocalizationManager.bootstrap(initialPreference:)` once at app launch
+/// (before any UI is built), and `LocalizationManager.apply(languageCode:)`
+/// whenever the user changes the language. Existing `NSLocalizedString(...)`
+/// call sites continue to work unchanged.
+public enum LocalizationManager {
+    /// Maps the picker's preference value (e.g. `"de"`, `"zh"`, `"system"`) to
+    /// the directory name of the matching `.lproj` resource.
+    private static func lprojName(for preference: String) -> String? {
+        switch preference {
+        case "system": return nil          // fall back to OS resolution
+        case "zh":     return "zh-Hans"    // picker value vs. bundle dir
+        default:       return preference   // "en", "de", "fr", ...
+        }
+    }
+
+    /// Install the bundle subclass and apply the initial preference. Safe to
+    /// call multiple times.
+    public static func bootstrap(initialPreference: String) {
+        object_setClass(Bundle.main, LocalizationBundle.self)
+        apply(languageCode: initialPreference)
+    }
+
+    /// Activate the given preference value. Pass `"system"` to revert to the
+    /// OS-resolved localization.
+    public static func apply(languageCode preference: String) {
+        guard let dir = lprojName(for: preference),
+              let path = Bundle.main.path(forResource: dir, ofType: "lproj"),
+              let bundle = Bundle(path: path) else {
+            SwizzleBundleStorage.activeBundle = nil
+            return
+        }
+        SwizzleBundleStorage.activeBundle = bundle
+    }
+}
+
+/// Holds the currently-selected sub-bundle. Module-private so only
+/// `LocalizationManager` mutates it.
+fileprivate enum SwizzleBundleStorage {
+    static var activeBundle: Bundle?
+}
+
+/// Subclass installed on `Bundle.main` so every `NSLocalizedString` lookup
+/// is routed through `localizedString(forKey:value:table:)` here first.
+private final class LocalizationBundle: Bundle, @unchecked Sendable {
+    override func localizedString(forKey key: String, value: String?, table tableName: String?) -> String {
+        if let active = SwizzleBundleStorage.activeBundle {
+            return active.localizedString(forKey: key, value: value, table: tableName)
+        }
+        return super.localizedString(forKey: key, value: value, table: tableName)
+    }
+}

--- a/web-renderer/src/help-overlay.ts
+++ b/web-renderer/src/help-overlay.ts
@@ -9,7 +9,7 @@ declare global {
     }
 }
 
-type Lang = 'zh' | 'en';
+type Lang = 'zh' | 'en' | 'de' | 'fr';
 
 interface I18n {
     title: string;
@@ -100,6 +100,74 @@ const STRINGS: Record<Lang, I18n> = {
             },
         },
     },
+    de: {
+        title: '⌨️ FluxMarkdown Funktionsübersicht',
+        contextBadgeQL: 'QuickLook-Vorschau',
+        contextBadgeApp: 'FluxMarkdown-App',
+        badgeApp: 'App',
+        qlBannerText: 'QuickLook fängt Tastatureingaben ab. Nur <strong>Cmd+Scrollen</strong> und <strong>Pinch-Geste</strong> funktionieren; benutze die Symbolleisten-Buttons oder öffne die Datei per Doppelklick in der App, um auf alle Funktionen zuzugreifen.',
+        footerQL: 'Klick auf den Hintergrund oder <kbd>✕</kbd>, um zu schließen',
+        footerApp: '<kbd>?</kbd> oder <kbd>Esc</kbd> zum Schließen · <kbd>⌘</kbd> 2 Sek. halten zum erneuten Öffnen',
+        toastText: '💡 Drücke <kbd>?</kbd> oder klicke auf <strong>?</strong> in der Symbolleiste, um alle Shortcuts zu sehen',
+        closeLabel: 'Schließen',
+        cmdHoldCheckboxLabel: 'Dieses Panel automatisch öffnen, wenn ⌘ 2 Sek. gehalten wird',
+        groups: {
+            searchNav: {
+                title: 'Suche & Navigation',
+                items: ['Suche öffnen / schließen', 'Nächster Treffer', 'Vorheriger Treffer', 'Suche schließen', 'TOC-Button (oben rechts)'],
+            },
+            zoom: {
+                title: 'Zoom',
+                items: ['Vergrößern', 'Verkleinern', 'Zoom zurücksetzen', 'Scroll-Zoom', 'Pinch-to-Zoom'],
+            },
+            view: {
+                title: 'Ansicht',
+                items: ['Vorschau / Quelltext umschalten', 'Quelltext-Button (oben rechts </>)', 'Theme umschalten (☀/🌙 oben rechts)'],
+            },
+            export: {
+                title: 'Exportieren',
+                items: ['Als HTML exportieren', 'Als PDF exportieren'],
+            },
+            settings: {
+                title: 'Einstellungen',
+                items: ['Einstellungen öffnen', 'Nach Updates suchen', 'Hilfe-Button (? oben rechts)', 'Dieses Hilfe-Panel anzeigen'],
+            },
+        },
+    },
+    fr: {
+        title: '⌨️ Guide des fonctionnalités de FluxMarkdown',
+        contextBadgeQL: 'Aperçu Coup d’œil',
+        contextBadgeApp: 'FluxMarkdown App',
+        badgeApp: 'App',
+        qlBannerText: 'Coup d’œil intercepte les événements clavier. Seuls <strong>Cmd+défilement</strong> et le <strong>geste de pincement</strong> fonctionnent ; utilisez les boutons de la barre d’outils ou double-cliquez pour ouvrir dans l’app et accéder à toutes les fonctions.',
+        footerQL: 'Cliquer sur le fond ou <kbd>✕</kbd> pour fermer',
+        footerApp: '<kbd>?</kbd> ou <kbd>Esc</kbd> pour fermer · Maintenir <kbd>⌘</kbd> 2 s pour rouvrir',
+        toastText: '💡 Appuyez sur <kbd>?</kbd> ou cliquez sur <strong>?</strong> dans la barre d’outils pour voir tous les raccourcis',
+        closeLabel: 'Fermer',
+        cmdHoldCheckboxLabel: 'Ouvrir automatiquement ce panneau en maintenant ⌘ pendant 2 s',
+        groups: {
+            searchNav: {
+                title: 'Recherche & Navigation',
+                items: ['Ouvrir / fermer la recherche', 'Résultat suivant', 'Résultat précédent', 'Fermer la recherche', 'Bouton TOC (en haut à droite)'],
+            },
+            zoom: {
+                title: 'Zoom',
+                items: ['Zoom avant', 'Zoom arrière', 'Réinitialiser le zoom', 'Zoom par défilement', 'Zoom par pincement'],
+            },
+            view: {
+                title: 'Affichage',
+                items: ['Basculer aperçu / source', 'Bouton source (en haut à droite </>)', 'Basculer le thème (☀/🌙 en haut à droite)'],
+            },
+            export: {
+                title: 'Exporter',
+                items: ['Exporter en HTML', 'Exporter en PDF'],
+            },
+            settings: {
+                title: 'Réglages',
+                items: ['Ouvrir les réglages', 'Rechercher les mises à jour', 'Bouton aide (? en haut à droite)', 'Afficher ce panneau d’aide'],
+            },
+        },
+    },
 };
 
 interface ShortcutGroup {
@@ -162,9 +230,12 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
 
 function detectLang(): Lang {
     const stored = window.__fluxLang;
-    if (stored === 'zh' || stored === 'en') return stored;
-    const sys = navigator.language || '';
-    return sys.startsWith('zh') ? 'zh' : 'en';
+    if (stored === 'zh' || stored === 'en' || stored === 'de' || stored === 'fr') return stored;
+    const sys = (navigator.language || '').toLowerCase();
+    if (sys.startsWith('zh')) return 'zh';
+    if (sys.startsWith('de')) return 'de';
+    if (sys.startsWith('fr')) return 'fr';
+    return 'en';
 }
 
 export class HelpOverlay {


### PR DESCRIPTION
The Settings *Language* picker previously controlled only the help overlay's language; native macOS menus, tooltips, Settings labels and the Welcome screen still followed the system locale. This change unifies both paths so a single picker switches the entire app.

## Architecture

- New `LocalizationManager` swaps `Bundle.main`'s class to a subclass that consults a per-language sub-bundle. Every existing `NSLocalizedString` call now resolves against the chosen `.lproj` at runtime; no call sites had to change.
- `bootstrap()` runs from `main.swift` (and from `PreviewViewController.init` for the QuickLook extension) before any UI is built.
- `AppearancePreference.uiLanguage` setter calls `apply()` so SwiftUI views re-render via `objectWillChange`.
- For things that live outside our bundle — AppKit's standard menu titles (*File / Edit / View / Window / Help*), SwiftUI's `Settings` scene title, and Sparkle's update window — `AppleLanguages` is pinned on the app's UserDefaults domain. These pick up the change on next launch, so the Settings *Language* section shows an inline *Restart Now* hint when the active selection differs from the launch-time selection.

## Scope

- Hardcoded English wrapped in `NSLocalizedString` across `MarkdownApp` (toolbar tooltips, command-group buttons), `SettingsView` (tabs, section headers, feature toggles, picker labels, code-theme rows), `WelcomeView` (title subtitle, drop zone, tips, buttons, NSOpenPanel prompt, accessibility label, Settings window title), and `AppearanceMode.displayName`.
- Added **Deutsch** and **Français** options to the picker; reworded the section description from *Interface language for the help panel* to *Interface language for the entire app*.
- Filled `en` / `zh-Hans` / `de` / `fr` `Localizable.strings` with all keys.
- Extended the WebRenderer help overlay to support `de` and `fr` alongside `zh`/`en`, including `navigator.language` fallback.
- `relaunchApp()` flushes `AppearancePreference`'s 0.3 s debounced shared-store writes and `UserDefaults.standard` before spawning the new instance, so the new process reads the current picker selection.

## Test plan

- [ ] Pick *Deutsch* → in-app strings switch immediately; restart hint appears.
- [ ] Click *Restart Now* → app relaunches; AppKit menu bar (*Ablage / Bearbeiten / …*), Settings window title, and Sparkle update window are now in German.
- [ ] Pick *System Default* → restart → everything reverts to OS-level language.
- [ ] QuickLook preview toast (*Cmd+click* a link in QL) renders in the picker's language.
- [ ] Help overlay (`?` in the doc window) renders in the picker's language for all four locales.

Refs #29 / follow-up to #31, #32.