### PR TITLE
fix(renderer): reflow soft line breaks within paragraphs (#38)

### DIFF
--- a/web-renderer/src/index.ts
+++ b/web-renderer/src/index.ts
@@ -325,7 +325,7 @@ function renderFrontMatterHtml(yamlStr: string): string {
 function buildMd(): MarkdownIt {
     const instance = new MarkdownIt({
         html: true,
-        breaks: true,
+        breaks: false,
         linkify: false,
         typographer: true,
         highlight: function (str: string, lang: string): string {

--- a/web-renderer/test/renderer.test.ts
+++ b/web-renderer/test/renderer.test.ts
@@ -233,4 +233,36 @@ invalid syntax here
     // Without renderVersion, no ?v= param should be appended (backward compatible)
     expect(img?.getAttribute('src')).toBe('local-md:///Users/me/docs/pic.png');
   });
+
+  test('should reflow semantic linefeeds within a paragraph (no <br> for soft breaks)', async () => {
+    const markdown = 'This is a sentence.\nThis is another sentence but still the same paragraph.';
+
+    await window.renderMarkdown(markdown);
+
+    const preview = document.getElementById('markdown-preview');
+    const paragraphs = preview?.querySelectorAll('p');
+    expect(paragraphs?.length).toBe(1);
+    expect(paragraphs?.[0].querySelector('br')).toBeNull();
+    expect(paragraphs?.[0].textContent).toBe('This is a sentence.\nThis is another sentence but still the same paragraph.');
+  });
+
+  test('should still separate paragraphs on a blank line', async () => {
+    const markdown = 'First paragraph.\n\nSecond paragraph.';
+
+    await window.renderMarkdown(markdown);
+
+    const preview = document.getElementById('markdown-preview');
+    const paragraphs = preview?.querySelectorAll('p');
+    expect(paragraphs?.length).toBe(2);
+  });
+
+  test('should preserve hard line breaks written as trailing two spaces', async () => {
+    const markdown = 'Line one.  \nLine two.';
+
+    await window.renderMarkdown(markdown);
+
+    const preview = document.getElementById('markdown-preview');
+    const paragraph = preview?.querySelector('p');
+    expect(paragraph?.querySelector('br')).not.toBeNull();
+  });
 });


### PR DESCRIPTION
Disable markdown-it `breaks` so single newlines inside a paragraph render as CommonMark soft breaks instead of `<br>` elements. Explicit hard breaks written with two trailing spaces remain intact.

Refs #38.