### PR TITLE
feat(quicklook): add .mdc (AI rules) support (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ brew install --cask xykong/tap/flux-markdown
 | 🔍 **Zoom & Pan** | Cmd +/-/0, Cmd+scroll, pinch gestures |
 | 💾 **Position Memory** | Remembers scroll position and last-viewed file |
 | 🌓 **Themes** | Light, Dark, and System-synchronized modes |
-| 📂 **File Formats** | Supports .md, .mdx, .rmd, .qmd, .mdoc, .mmd, .livemd, .mkd, .mkdn, .mkdown, .mdwn, .mdown, .markdown |
+| 📂 **File Formats** | Supports .md, .mdx, .rmd, .qmd, .mdoc, .mdc, .mmd, .livemd, .mkd, .mkdn, .mkdown, .mdwn, .mdown, .markdown |
 
 ---
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -76,7 +76,7 @@ brew install --cask xykong/tap/flux-markdown
 | 🔍 **Zoom y paneo** | Cmd +/-/0, Cmd+scroll, gestos de pellizco |
 | 💾 **Memoria de posición** | Recuerda la posición de desplazamiento y el último archivo visto |
 | 🌓 **Temas** | Modos claro, oscuro y sincronizado con el sistema |
-| 📂 **Formatos de archivo** | Soporta .md, .mdx, .rmd, .qmd, .mdoc, .mmd, .livemd, .mkd, .mkdn, .mkdown, .mdwn, .mdown, .markdown |
+| 📂 **Formatos de archivo** | Soporta .md, .mdx, .rmd, .qmd, .mdoc, .mdc, .mmd, .livemd, .mkd, .mkdn, .mkdown, .mdwn, .mdown, .markdown |
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -76,7 +76,7 @@ brew install --cask xykong/tap/flux-markdown
 | 🔍 **缩放与平移** | Cmd +/-/0、Cmd+滚轮、触控板捏合 |
 | 💾 **位置记忆** | 记忆每个文件的滚动位置及最后查看的文件 |
 | 🌓 **主题** | 亮色、暗色、跟随系统 |
-| 📂 **文件格式** | 支持 .md, .mdx, .rmd, .qmd, .mdoc, .mkd, .mkdn, .mkdown |
+| 📂 **文件格式** | 支持 .md, .mdx, .rmd, .qmd, .mdoc, .mdc, .mkd, .mkdn, .mkdown |
 
 ---
 

--- a/Sources/Markdown/Info.plist
+++ b/Sources/Markdown/Info.plist
@@ -38,6 +38,7 @@
 				<string>com.fluxmarkdown.rmd</string>
 				<string>com.fluxmarkdown.qmd</string>
 				<string>com.fluxmarkdown.mdoc</string>
+				<string>com.fluxmarkdown.mdc</string>
 				<string>com.fluxmarkdown.mmd</string>
 				<string>com.fluxmarkdown.livemd</string>
 				<string>com.fluxmarkdown.markdown</string>
@@ -255,6 +256,23 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>mdoc</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>AI Rules Markdown Document</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.fluxmarkdown.mdc</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mdc</string>
 				</array>
 			</dict>
 		</dict>

--- a/Sources/MarkdownPreview/Info.plist
+++ b/Sources/MarkdownPreview/Info.plist
@@ -32,6 +32,7 @@
 				<string>com.fluxmarkdown.rmd</string>
 				<string>com.fluxmarkdown.qmd</string>
 				<string>com.fluxmarkdown.mdoc</string>
+				<string>com.fluxmarkdown.mdc</string>
 				<string>com.fluxmarkdown.mmd</string>
 				<string>com.fluxmarkdown.livemd</string>
 				<string>com.fluxmarkdown.markdown</string>

--- a/Tests/MarkdownTests/FileExtensionTests.swift
+++ b/Tests/MarkdownTests/FileExtensionTests.swift
@@ -52,6 +52,12 @@ final class FileExtensionTests: XCTestCase {
                       "test.livemd fixture must exist")
     }
 
+    func testFixtureExists_mdc() {
+        let url = fixturesURL.appendingPathComponent("test.mdc")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
+                      "test.mdc fixture must exist")
+    }
+
     func testFixtureExists_markdown() {
         let url = fixturesURL.appendingPathComponent("test.markdown")
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path),
@@ -212,6 +218,12 @@ final class FileExtensionTests: XCTestCase {
         XCTAssertEqual(processed, raw, ".qmd content must not be wrapped")
     }
 
+    func testNoWrapping_mdcExtension() {
+        let raw = "---\ndescription: rules\nglobs: \"*.tsx\"\n---\n\n# Rule"
+        let processed = applyContentPreprocessing(content: raw, fileExtension: "mdc")
+        XCTAssertEqual(processed, raw, ".mdc content must not be wrapped")
+    }
+
     // MARK: - UTI Declaration Tests (Info.plist)
 
     func testUTIDeclarations_appInfoPlistExists() {
@@ -298,6 +310,30 @@ final class FileExtensionTests: XCTestCase {
                       "Extension Info.plist QLSupportedContentTypes must include com.fluxmarkdown.mmd")
     }
 
+    func testUTIDeclarations_appPlistContainsMdcUTI() throws {
+        let plistURL = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Markdown/Info.plist")
+        let plistContent = try String(contentsOf: plistURL, encoding: .utf8)
+        XCTAssertTrue(plistContent.contains("com.fluxmarkdown.mdc"),
+                      "App Info.plist must declare com.fluxmarkdown.mdc UTI")
+        XCTAssertTrue(plistContent.contains("<string>mdc</string>"),
+                      "App Info.plist must map .mdc extension to UTI")
+    }
+
+    func testUTIDeclarations_extensionPlistContainsMdcUTI() throws {
+        let plistURL = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/MarkdownPreview/Info.plist")
+        let plistContent = try String(contentsOf: plistURL, encoding: .utf8)
+        XCTAssertTrue(plistContent.contains("com.fluxmarkdown.mdc"),
+                      "Extension Info.plist QLSupportedContentTypes must include com.fluxmarkdown.mdc")
+    }
+
     func testUTIDeclarations_extensionPlistContainsLivemdUTI() throws {
         let plistURL = URL(fileURLWithPath: #file)
             .deletingLastPathComponent()
@@ -324,6 +360,7 @@ final class FileExtensionTests: XCTestCase {
             "com.fluxmarkdown.rmd",
             "com.fluxmarkdown.qmd",
             "com.fluxmarkdown.mdoc",
+            "com.fluxmarkdown.mdc",
             "com.fluxmarkdown.mmd",
             "com.fluxmarkdown.livemd",
             "com.fluxmarkdown.markdown",
@@ -347,6 +384,7 @@ final class FileExtensionTests: XCTestCase {
         let supportedExtensions: [(filename: String, ext: String)] = [
             ("test-mermaid.mmd",          "mmd"),
             ("test.livemd",               "livemd"),
+            ("test.mdc",                  "mdc"),
             ("test.mdwn",                 "mdwn"),
             ("test.markdown",             "markdown"),
             ("test.mdown",                "mdown"),

--- a/Tests/fixtures/test.mdc
+++ b/Tests/fixtures/test.mdc
@@ -1,0 +1,11 @@
+---
+description: Example AI rules file
+globs: "**/*.tsx"
+alwaysApply: false
+---
+
+# Component conventions
+
+- Use functional components with hooks.
+- Co-locate styles in a `.module.css` file next to the component.
+- Prefer composition over prop drilling.


### PR DESCRIPTION
Adds `.mdc` (Cursor / AI assistant rules — Markdown with YAML frontmatter) as a supported file type.

- Declares `com.fluxmarkdown.mdc` as an imported UTI conforming to `public.plain-text` in the app's `Info.plist`.
- Adds the UTI to `LSItemContentTypes` (app) and `QLSupportedContentTypes` (QuickLook extension).
- Adds a fixture `Tests/fixtures/test.mdc` and four `FileExtensionTests` cases (fixture existence, no-wrapping preprocessing, both plists declare the UTI).
- Mentions `.mdc` in the supported-formats row of `README.md`, `README_ES.md`, `README_ZH.md`.

The existing YAML-frontmatter rendering handles MDC content unchanged; no renderer changes are needed.

Closes #41.