### PR TITLE
fix(quicklook): add net.ia.markdown UTI to fix conflict with iA Writer (#40)

### DIFF
--- a/Sources/Markdown/Info.plist
+++ b/Sources/Markdown/Info.plist
@@ -34,6 +34,7 @@
 			<array>
 				<string>net.daringfireball.markdown</string>
 				<string>public.markdown</string>
+				<string>net.ia.markdown</string>
 				<string>com.fluxmarkdown.mdx</string>
 				<string>com.fluxmarkdown.rmd</string>
 				<string>com.fluxmarkdown.qmd</string>

--- a/Sources/MarkdownPreview/Info.plist
+++ b/Sources/MarkdownPreview/Info.plist
@@ -28,6 +28,7 @@
 			<array>
 				<string>net.daringfireball.markdown</string>
 				<string>public.markdown</string>
+				<string>net.ia.markdown</string>
 				<string>com.fluxmarkdown.mdx</string>
 				<string>com.fluxmarkdown.rmd</string>
 				<string>com.fluxmarkdown.qmd</string>

--- a/Tests/MarkdownTests/FileExtensionTests.swift
+++ b/Tests/MarkdownTests/FileExtensionTests.swift
@@ -298,6 +298,28 @@ final class FileExtensionTests: XCTestCase {
                       "Extension Info.plist QLSupportedContentTypes must include com.fluxmarkdown.mmd")
     }
 
+    func testUTIDeclarations_appPlistContainsIaWriterUTI() throws {
+        let plistURL = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Markdown/Info.plist")
+        let plistContent = try String(contentsOf: plistURL, encoding: .utf8)
+        XCTAssertTrue(plistContent.contains("net.ia.markdown"),
+                      "App Info.plist must declare net.ia.markdown so .md files tagged by iA Writer's UTI open in FluxMarkdown")
+    }
+
+    func testUTIDeclarations_extensionPlistContainsIaWriterUTI() throws {
+        let plistURL = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/MarkdownPreview/Info.plist")
+        let plistContent = try String(contentsOf: plistURL, encoding: .utf8)
+        XCTAssertTrue(plistContent.contains("net.ia.markdown"),
+                      "Extension Info.plist QLSupportedContentTypes must include net.ia.markdown so QuickLook is invoked when iA Writer is installed")
+    }
+
     func testUTIDeclarations_extensionPlistContainsLivemdUTI() throws {
         let plistURL = URL(fileURLWithPath: #file)
             .deletingLastPathComponent()
@@ -320,6 +342,7 @@ final class FileExtensionTests: XCTestCase {
         let requiredUTIs = [
             "net.daringfireball.markdown",
             "public.markdown",
+            "net.ia.markdown",
             "com.fluxmarkdown.mdx",
             "com.fluxmarkdown.rmd",
             "com.fluxmarkdown.qmd",


### PR DESCRIPTION
On macOS, when iA Writer is installed it claims `net.ia.markdown` for `.md` files, and LaunchServices returns that UTI from `mdls`. Because the FluxMarkdown QuickLook extension only declared `net.daringfireball.markdown` and `public.markdown`, the extension was never invoked and Finder fell back to the plain-text renderer.

- Add `net.ia.markdown` to `QLSupportedContentTypes` in `Sources/MarkdownPreview/Info.plist` (fixes the QuickLook half).
- Add `net.ia.markdown` to `LSItemContentTypes` in `Sources/Markdown/Info.plist` so the app also accepts `.md` files tagged with the iA UTI for "Open With" / drag-drop.
- No `UTImportedTypeDeclarations` entry is added — `net.ia.markdown` is owned by iA Writer; FluxMarkdown only declares that it consumes it.
- Add two `FileExtensionTests` cases and extend `testUTIDeclarations_bothPlistsDeclareSameUTIs` so a future regression is caught.

Closes #40.